### PR TITLE
Use importing best practice & Ignore Python cache files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 /docs/source/
 /docs/stubs/
 !/main_notebook.ipynb
+
+__pycache__
+*.pyc


### PR DESCRIPTION
Hello there! I am skimming the code and propose a few changes to add...

The first one is to change the import style to the Python best practice to import modules & packages vs. importing objects directly.  This way it allows to understand a namespace of the object straightaway, without looking into the top of the module. Secondly, it reduces repetition in importing the same stuff from the same module which in the end makes the code more readable. More on this point in [Google Python Styleguide](https://google.github.io/styleguide/pyguide.html#22-imports).
The only change that is needed is like this:
```diff
- from .settings import PeriodLength
+ from okama import settings
```
**I have already made the change into the `okama.asset` module so that it's more clear!**
Of course, this change is just the beginning, and the continuation of adding more imports like this depends on the agreement with the current main maintainer of this project @chilango74

The second one is to add entries excluding all the `__pycache__` directories and `*.pyc` files which are often generated while running the Python code. This way there would be less redundant output in the Git status command!