### PR TITLE
Fixed right frontier and added tests

### DIFF
--- a/tests/test_frontier_reb.py
+++ b/tests/test_frontier_reb.py
@@ -59,3 +59,64 @@ def test_max_return(init_efficient_frontier_reb):
 @mark.frontier
 def test_ef_points_reb(init_efficient_frontier_reb):
     assert init_efficient_frontier_reb.ef_points["CAGR"].iloc[1] == approx(0.1889, abs=1e-2)
+
+
+@mark.rebalance
+@mark.frontier
+def convex_right_frontier():
+
+    ls_m = ["SPY.US", "GLD.US", "PGJ.US", "RGBITR.INDX", "MCFTR.INDX"]
+    curr_rub = "RUB"
+
+    x = ok.EfficientFrontierReb(
+        assets=ls_m,
+        first_date="2005-01",
+        last_date="2020-11",
+        ccy=curr_rub,
+        rebalancing_period="year", 
+        n_points=5,
+        verbose=True,
+    )
+
+    result = x._max_cagr_asset_right_to_max_cagr
+
+    expected_result = {
+        "max_asset_cagr": 0.17520700138002665,
+        "ticker_with_largest_cagr": "PGJ.US",  
+        "list_position": 2 
+    }
+
+    assert result == expected_result
+
+@mark.rebalance
+@mark.frontier
+def nonconvex_right_frontier():
+
+    ls_m = ["SPY.US", "GLD.US", "VB.US", "RGBITR.INDX", "MCFTR.INDX"]
+    curr_rub = "RUB"
+
+    x = ok.EfficientFrontierReb(
+        assets=ls_m,
+        first_date="2004-12",
+        last_date="2020-12",
+        ccy=curr_rub,
+        rebalancing_period="year", 
+        n_points=5,
+        verbose=True,
+    )
+
+    result = x._max_cagr_asset_right_to_max_cagr
+
+    expected_result = {
+        "max_asset_cagr": 0.15691138904751512,
+        "ticker_with_largest_cagr": "MCFTR.INDX",  
+        "list_position": 4
+    }
+
+    assert result == expected_result
+
+
+
+
+
+


### PR DESCRIPTION
Fixed right frontier and added tests

## Summary by Sourcery

This pull request fixes the logic for identifying the asset with the maximum CAGR to the right of the global maximum CAGR point on the efficient frontier and adds corresponding tests to ensure the correctness of the implementation.

Bug Fixes:
- Fixed the calculation of the asset with the maximum CAGR (Compound Annual Growth Rate) to the right of the global maximum CAGR point on the efficient frontier.

Tests:
- Added tests to verify the correct identification of the asset with the maximum CAGR to the right of the global maximum CAGR point, covering both convex and non-convex frontier scenarios.